### PR TITLE
[codex] Roll up dependabot updates

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -151,7 +151,7 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
 
       - name: Install cargo-edit
-        uses: taiki-e/install-action@0abfcd587b70a713fdaa7fb502c885e2112acb15 # v2.75.7
+        uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1 # v2.75.22
         with:
           tool: cargo-edit@0.13.9
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache cargo registry
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cargo/registry/index
@@ -106,7 +106,7 @@ jobs:
           echo "OPENSSL_DIR=$(brew --prefix openssl@3)" >> "$GITHUB_ENV"
 
       - name: Cache cargo
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cargo/registry/index
@@ -141,7 +141,7 @@ jobs:
           sudo apt-get install -y libssl-dev pkg-config
 
       - name: Cache cargo registry
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cargo/registry/index
@@ -176,7 +176,7 @@ jobs:
           sudo apt-get install -y libssl-dev pkg-config
 
       - name: Cache cargo
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cargo/registry/index
@@ -249,7 +249,7 @@ jobs:
           sudo apt-get install -y libssl-dev pkg-config
 
       - name: Cache cargo
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cargo/registry/index

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
           toolchain: ${{ env.RUST_STABLE_VERSION }}
 
       - name: Install cargo-hack
-        uses: taiki-e/install-action@0abfcd587b70a713fdaa7fb502c885e2112acb15 # v2.75.7
+        uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1 # v2.75.22
         with:
           tool: cargo-hack@0.6.44
 
@@ -239,7 +239,7 @@ jobs:
           components: llvm-tools-preview
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@0abfcd587b70a713fdaa7fb502c885e2112acb15 # v2.75.7
+        uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1 # v2.75.22
         with:
           tool: cargo-llvm-cov@0.8.5
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -163,7 +163,7 @@ jobs:
           fetch-depth: 0
 
       - name: TruffleHog scan
-        uses: trufflesecurity/trufflehog@47e7b7cd74f578e1e3145d48f669f22fd1330ca6 # v3.94.3
+        uses: trufflesecurity/trufflehog@17456f8c7d042d8c82c9a8ca9e937231f9f42e26 # v3.95.2
         with:
           extra_args: --only-verified
         continue-on-error: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,7 +34,7 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
 
       - name: Install cargo-audit
-        uses: taiki-e/install-action@0abfcd587b70a713fdaa7fb502c885e2112acb15 # v2.75.7
+        uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1 # v2.75.22
         with:
           tool: cargo-audit@0.22.1
 
@@ -66,7 +66,7 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
 
       - name: Install cargo-deny
-        uses: taiki-e/install-action@0abfcd587b70a713fdaa7fb502c885e2112acb15 # v2.75.7
+        uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1 # v2.75.22
         with:
           tool: cargo-deny@0.19.0
 
@@ -92,7 +92,7 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
 
       - name: Install cargo-cyclonedx
-        uses: taiki-e/install-action@0abfcd587b70a713fdaa7fb502c885e2112acb15 # v2.75.7
+        uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1 # v2.75.22
         with:
           tool: cargo-cyclonedx@0.5.9
 
@@ -143,7 +143,7 @@ jobs:
           sudo apt-get install -y libssl-dev pkg-config
 
       - name: Install cargo-semver-checks
-        uses: taiki-e/install-action@0abfcd587b70a713fdaa7fb502c885e2112acb15 # v2.75.7
+        uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1 # v2.75.22
         with:
           tool: cargo-semver-checks@0.47.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2724,9 +2724,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3044,9 +3044,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -351,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ oauth2 = { version = "5.0.0", default-features = false, features = ["reqwest", "
 rand = { version = "0.10.1", optional = true }
 
 # CLI dependencies (optional)
-clap = { version = "4.6.0", features = ["derive", "env"], optional = true }
+clap = { version = "4.6.1", features = ["derive", "env"], optional = true }
 colored = { version = "3.1.1", optional = true }
 indicatif = { version = "0.18.4", optional = true }
 dirs = { version = "6.0.0", optional = true }
@@ -81,7 +81,7 @@ mcp-oauth = ["mcp", "oauth2", "rand", "uuid", "tower", "tower-http", "axum-extra
 tokio-test = "0.4.5"
 mockito = "1.7.2"
 wiremock = "0.6.5"
-clap = { version = "4.6.0", features = ["derive"] }
+clap = { version = "4.6.1", features = ["derive"] }
 tempfile = "3.27.0"
 futures = "0.3.32"
 uuid = { version = "1.23.0", features = ["v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ required-features = ["cli"]
 reqwest = { version = "0.13.2", features = ["json", "form", "rustls", "multipart"], default-features = false }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-tokio = { version = "1.51.0", features = ["rt-multi-thread", "macros", "time", "fs", "io-std"] }
+tokio = { version = "1.52.1", features = ["rt-multi-thread", "macros", "time", "fs", "io-std"] }
 tokio-stream = "0.1.18"
 thiserror = "2.0.18"
 async-trait = "0.1.89"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter"], optional =
 # The MCP JWT flow only uses HMAC signing, so avoid pulling the RustCrypto RSA stack.
 jsonwebtoken = { version = "10.3.0", optional = true, default-features = false, features = ["aws_lc_rs"] }
 serde_with = { version = "3.18.0", optional = true }
-uuid = { version = "1.23.0", features = ["v4", "serde"], optional = true }
+uuid = { version = "1.23.1", features = ["v4", "serde"], optional = true }
 tower = { version = "0.5.3", features = ["util"], optional = true }
 tower-http = { version = "0.6.8", features = ["cors", "trace"], optional = true }
 axum-extra = { version = "0.12.5", features = ["typed-header"], optional = true }
@@ -84,7 +84,7 @@ wiremock = "0.6.5"
 clap = { version = "4.6.1", features = ["derive"] }
 tempfile = "3.27.0"
 futures = "0.3.32"
-uuid = { version = "1.23.0", features = ["v4"] }
+uuid = { version = "1.23.1", features = ["v4"] }
 
 [[example]]
 name = "elasticsearch_indexer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ sha2 = "0.11.0"
 urlencoding = "2.1.3"
 
 # MCP feature dependencies (optional)
-axum = { version = "0.8.8", optional = true }
+axum = { version = "0.8.9", optional = true }
 tokio-util = { version = "0.7.18", features = ["io"], optional = true }
 anyhow = { version = "1.0.102", optional = true }
 regex = { version = "1.12.3", optional = true }


### PR DESCRIPTION
## Summary
Consolidates the current open Dependabot updates into a single branch and PR.

Included updates:
- PR #63: `taiki-e/install-action` `2.75.7` -> `2.75.22`
- PR #64: `clap` `4.6.0` -> `4.6.1` in development dependencies
- PR #65: `trufflesecurity/trufflehog` `3.94.3` -> `3.95.2`
- PR #66: `actions/cache` `5.0.4` -> `5.0.5`
- PR #67: `tokio` `1.51.0` -> `1.52.1`
- PR #68: `axum` `0.8.8` -> `0.8.9`
- PR #69: `uuid` `1.23.0` -> `1.23.1`

## Why
Rolling these into one PR reduces review overhead and ensures the overlapping `Cargo.toml`, `Cargo.lock`, and workflow changes are validated together.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-features --all-targets -- -D warnings`
- `cargo check --locked --no-default-features`
- `cargo test --locked --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --all-features --no-deps --document-private-items`

## Supersedes
Closes #63, #64, #65, #66, #67, #68, #69 once this rollup is merged.